### PR TITLE
Added save functionality for user notes

### DIFF
--- a/db/db.json
+++ b/db/db.json
@@ -1,6 +1,10 @@
 [
     {
-        "title":"Test Title",
-        "text":"Test text"
+        "title": "Test Title",
+        "text": "Test text"
+    },
+    {
+        "title": "test",
+        "text": "test"
     }
 ]

--- a/helpers/fsUtils.js
+++ b/helpers/fsUtils.js
@@ -1,0 +1,20 @@
+const fs = require('fs');
+
+const writeToFile = (destination, content) =>
+  fs.writeFile(destination, JSON.stringify(content, null, 4), (err) =>
+    err ? console.error(err) : console.info(`Note data save successfull!`)
+  );
+
+const readAndAppend = (content, file) => {
+    fs.readFile(file, 'utf8', (err, data) => {
+      if (err) {
+        console.error(err);
+      } else {
+        const parsedData = JSON.parse(data);
+        parsedData.push(content);
+        writeToFile(file, parsedData);
+      }
+    });
+};
+
+module.exports = readAndAppend;

--- a/routes/api.js
+++ b/routes/api.js
@@ -1,10 +1,46 @@
 // Passes 'express' from server.js to use within api.js
 const app = require('express').Router();
-const savedNotes = require('../db/db.json');
+const readAndAppend = require('../helpers/fsUtils');
+const fs = require('fs');
+
 
 // Pulls in save note data from db.json and displays it on /notes webpage
 app.get('/notes', (req, res) => {
-  res.json(savedNotes);
+
+  // savedNotes reads the data within db.json
+  const savedNotes = fs.readFileSync('./db/db.json');
+
+  // process parses any data to the body within savedNotes
+  const process = JSON.parse(savedNotes);
+  
+  // Responds by parsing new save note data to the body in db.json
+  res.json(process);
+});
+
+app.post('/notes', (req, res) => {
+  // logs the terminal stating that the user input was received
+  console.info(`${req.body.title} note recieved`);
+    
+  // title and text are constants for the required body
+  const { title, text } = req.body
+  
+  // if there is data within req.body
+  if (req.body) {
+
+    // then it will pass the data into the newNote constant
+    const newNote = {
+      title,
+      text
+    };
+
+    // calls readAndAppend with file to format newNote data with
+    readAndAppend(newNote, './db/db.json');
+    res.json(`${req.body.title} note has been added!`);
+  } else {
+
+    // otherwise it will display the following error message
+    res.error('Unable to add note at this time');
+  }
 });
 
 module.exports = app;

--- a/server.js
+++ b/server.js
@@ -5,6 +5,10 @@ const routes = require('./routes/index.js');
 const app = express();
 const PORT = 3001;
 
+// 
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
+
 // Utilizes Middleware within routes/index.js
 app.use(routes);
 


### PR DESCRIPTION
The following branch can now allow the user to save a note (on their instance of the application) by including data into the 'title' and 'text' fields and then by clicking the 'save' icon.

I was able to achieve this by implementing some code from the 'fsUtils.js' file from activity 24 in express.js which achieves parsing and pushing the user data and writing it to the 'db.json' file in .json formatting (while being presentable within the body and not restructuring/modifying the form of the contents within the file!).

After a user clicks the 'save' icon, the request is then communicated to the backend (or 'api.js') by sending a response to the console (Line 22) and passing in the user inputted data into the 'newNote' constant (Lines 28-34) and calling 'readAndAppend' function to refracture the contents within 'newNote' into JSON formatting (Line 37), writing and pushing it into the body within 'db.json'.

Once completed it will then send a message back to the web application to 'not leave the phone hanging' (Line 38).

After a change to 'db.json' is made the application is then able to recognize this (due to 'fs.readFileSync' on Line 11) and update the saved notes list on the left-hand side to reflect/align with the saved note data in 'db.json' (Lines 8-18).

Speaking to 'savedNotes', before it was pulling in data from 'db.json' however it wasn't able to scan or pull the file in again unless the server restarted, I since found out how 'fs.readFileSync' is able to read the file for changes and reflect those changes by parsing the newer note data on Line 14 without having the server to restart.

All this to say that none of this would be possible without Lines 9 and 10 within 'server.js' acting as the middleware that passes any and all JSON requests that come in, without those two lines none of this would function.